### PR TITLE
Fix array syntax to avoid PHP fatals on php 5.3.

### DIFF
--- a/gdpr_cookies.module
+++ b/gdpr_cookies.module
@@ -216,44 +216,44 @@ function third_party_service_form($form, &$form_state, $entity) {
     '#value' => $entity,
   );
 
-  $form['name'] = [
+  $form['name'] = array(
     '#type' => 'textfield',
     '#title' => t('Name'),
     '#description' => t('This is the name of the service.'),
     '#default_value' => property_exists($third_party_service, 'name') ?  $third_party_service->getName() : '',
-  ];
+  );
 
-  $form['vanisher'] = [
+  $form['vanisher'] = array(
     '#type' => 'select',
     '#title' => 'Vanisher',
     '#description' => t('Choose the vanisher for the service control.'),
     '#default_value' => property_exists($third_party_service, 'vanisher') ?  $third_party_service->getVanisher() : '',
-    '#options' => $vanisher->getInstalledVanisherNames() ?: [], // todo lars
+    '#options' => $vanisher->getInstalledVanisherNames() ?: array(), // todo lars
     '#empty_value' => '',
     '#required' => TRUE,
-  ];
+  );
 
-  $form['enabled'] = [
+  $form['enabled'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable Service Control?'),
     '#description' => t('If activated this service will be controlled with tarteaucitron.'),
     '#default_value' => property_exists($third_party_service, 'enabled') ?  $third_party_service->isEnabled() : FALSE,
-  ];
+  );
 
-  $form['optional_fields'] = [
+  $form['optional_fields'] = array(
     '#type' => 'fieldset',
     '#title' => t('Optional Fields'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
-  ];
+  );
 
-  $form['optional_fields']['info'] = [
+  $form['optional_fields']['info'] = array(
     '#type' => 'textarea',
     '#title' => t('Info Content'),
     '#description' => t('This content will be displayed instead until the user activates the service.'),
     '#default_value' => property_exists($third_party_service, 'info') ?  $third_party_service->getInfo() : '',
     '#required' => FALSE,
-  ];
+  );
 
   $form['submit'] = array(
     '#type' => 'submit',
@@ -324,14 +324,14 @@ function third_party_service_form_submit($form, &$form_state) {
 
 
   if ($id) {
-    backdrop_set_message(t('Saved the %label Third Party Service.', [
+    backdrop_set_message(t('Saved the %label Third Party Service.', array(
       '%label' => $entity->label(),
-    ]));
+    )));
   }
   else {
-    backdrop_set_message(t('The %label Third Party Service was not saved.', [
+    backdrop_set_message(t('The %label Third Party Service was not saved.', array(
       '%label' => $entity->label(),
-    ]));
+    )));
   }
 
   $form_state['redirect'] = 'admin/config/system/gdpr-cookies/third-party-service';
@@ -488,12 +488,12 @@ function gdpr_cookies_settings_page() {
     '#default_value' => config_get('gdpr_cookies.settings','gdpr_cookies_remove_credit') ? TRUE : FALSE,
   );
 
-  $form['gdpr_cookies_default_rejected'] = [
+  $form['gdpr_cookies_default_rejected'] = array(
     '#type' => 'checkbox',
     '#title' => t('Default Rejected'),
     '#description' => t('Should all services be rejected by default?'),
     '#default_value' => config_get('gdpr_cookies.settings','gdpr_cookies_default_rejected') ? TRUE : FALSE,
-  ];
+  );
 
   // Add a submit button
   $form['actions']['#type'] = 'actions';


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/gdpr_cookies/issues/7